### PR TITLE
refactor(sms): uniformly return errors in promise

### DIFF
--- a/lib/airtime.js
+++ b/lib/airtime.js
@@ -14,17 +14,17 @@ function Airtime(options) {
 }
 
 Airtime.prototype.send = function (params) {
- 
+
     let _self       = this;
     let options     = _.cloneDeep(params);
     let _recipients = [];
- 
+
     // Validate params
     let _validateParams = function () {
- 
+
         var constraints = {
             recipients: function (value) {
- 
+
                 if (validate.isEmpty(value)) {
                     return {
                         presence: {
@@ -32,26 +32,26 @@ Airtime.prototype.send = function (params) {
                         }
                     };
                 }
- 
+
                 if (!validate.isArray(value)) {
                     return {
                         format: 'must be an array'
                     };
                 }
- 
+
                 for(let i in value) {
                     let recipient = value[i];
                     let phone     = recipient.phoneNumber;
                     let amount    = recipient.amount;
- 
+
                     if (validate.isEmpty(phone) ||
                         validate.isEmpty(amount)) {
- 
+
                         return {
                             format: 'must all specify phoneNumber and amount'
                         }
                     }
- 
+
                     if (!(/^\+?\d+$/).test(phone)) {
                         return {
                             format: 'must not contain invalid phone numbers'
@@ -63,7 +63,7 @@ Airtime.prototype.send = function (params) {
                             format: 'must only contain amount between 10 and 10000'
                         }
                     }
- 
+
                     // format amount with currency
                     let currency     = DEFAULT_CURRENCY;
                     recipient.amount = validate.format(
@@ -72,12 +72,12 @@ Airtime.prototype.send = function (params) {
                     );
 		    _recipients.push( { 'phoneNumber': phone, 'amount': recipient.amount });
                 };
- 
+
                 return null;
- 
+
             }
         };
- 
+
         let error = validate(options, constraints);
         if (error) {
             // TODO should this be rejected by promise instead?
@@ -86,14 +86,13 @@ Airtime.prototype.send = function (params) {
     }
 
     _validateParams();
- 
+
     return new Promise(function (resolve, reject) {
- 
+
         let body = {
             username: _self.options.username,
             recipients: _recipients
         };
-	console.log(body);
 
         let rq = unirest.post(Common.AIRTIME_URL);
         rq.headers({
@@ -113,7 +112,7 @@ Airtime.prototype.send = function (params) {
         });
 
     });
- 
+
 };
 
 module.exports = Airtime;

--- a/lib/sms.js
+++ b/lib/sms.js
@@ -15,6 +15,8 @@ function SMS(options) {
 
     this._send = function (params, isBulk, isPremium) {
 
+        var validationError;
+
         // Validate params
         var _validateParams = function () {
 
@@ -92,7 +94,7 @@ function SMS(options) {
                 for (var k in error) {
                     msg += error[k] + "; ";
                 }
-                throw new Error(msg);
+                validationError = new Error(msg);
             }
         };
 
@@ -108,6 +110,10 @@ function SMS(options) {
         }
 
         return new Promise(function (resolve, reject) {
+
+            if (validationError) {
+                return reject(validationError);
+            }
 
             var body = {
                 username: _self.options.username,
@@ -215,10 +221,7 @@ SMS.prototype.createSubscription = function (params) {
         }
     };
 
-    var error = validate(opts, constraints);
-    if (error) {
-        throw error;
-    }
+    var validationError = validate(opts, constraints);
 
     var body = {
     	username: _self.options.username,
@@ -228,6 +231,10 @@ SMS.prototype.createSubscription = function (params) {
     };
 
     return new Promise(function (resolve, reject) {
+
+        if (validationError) {
+            return reject(validationError);
+        }
 
         var rq = unirest.post(Common.BASE_URL + '/subscription/create');
         rq.headers({
@@ -265,14 +272,16 @@ SMS.prototype.fetchSubscription = function (params) {
         }
     };
 
-    var error = validate(opts, constraints);
-    if (error) {
-        throw error;
-    }
+    var validationError = validate(opts, constraints);
 
     opts.lastReceivedId = opts.lastReceivedId || 0;
 
     return new Promise(function (resolve, reject) {
+
+        // throw validation error inside the promise chain
+        if (validationError) {
+            return reject(validationError);
+        }
 
         var rq = unirest.get(Common.BASE_URL + '/subscription');
         rq.headers({
@@ -295,6 +304,5 @@ SMS.prototype.fetchSubscription = function (params) {
 
     });
 };
-
 
 module.exports = SMS;

--- a/test/airtime.js
+++ b/test/airtime.js
@@ -7,51 +7,51 @@ var fixtures = require('./fixtures');
 var AfricasTalking, airtime;
 
 describe('AIRTIME', function(){
-   
+
     this.timeout(5000);
 
     before(function () {
         AfricasTalking = require('../lib')(fixtures.TEST_ACCOUNT);
         airtime = AfricasTalking.AIRTIME;
     });
-    
+
     it('validates options', function(){
-        
+
         var options = {};
-        
+
         (function() {
             let p = airtime.send(options);
         }).should.throw();
-        
+
         options.recipients = [];
         (function() {
             let p = airtime.send(options);
         }).should.throw();
-        
+
         options.recipients.push(
             {phoneNumber: 'not phone', amount:'NaN'}
             );
         (function() {
             let p = airtime.send(options);
         }).should.throw();
-        
+
         options.recipients = [
             {phoneNumber: '0712345678', amount:9}
         ];
         (function() {
             let p = airtime.send(options);
         }).should.throw();
-        
+
         options.recipients = [
             {phoneNumber: '0712345678', amount:10001}
         ];
         (function() {
             let p = airtime.send(options);
         }).should.throw();
-        
-        
+
+
     });
-    
+
     it('sends airtime to one', function (done) {
         var opts = {
            recipients: [
@@ -61,7 +61,7 @@ describe('AIRTIME', function(){
                }
            ]
         };
-       
+
         airtime.send(opts)
             .then(function(resp){
                 resp.should.have.property('responses');
@@ -71,11 +71,11 @@ describe('AIRTIME', function(){
                 console.error(err);
                 done();
             });
-            
+
     });
-    
+
     it('sends airtime to many', function(done){
-       
+
        var opts = {
            recipients: [
                {
@@ -88,7 +88,7 @@ describe('AIRTIME', function(){
                }
            ]
        };
-       
+
        airtime.send(opts)
             .then(function(resp){
                 resp.should.have.property('responses');
@@ -98,8 +98,8 @@ describe('AIRTIME', function(){
                 console.error(err);
                 done();
             });
-        
+
     });
-   
-    
+
+
 });

--- a/test/sms.js
+++ b/test/sms.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var should = require('should');
-var validate = require('validate.js');
 var fixtures = require('./fixtures');
 
 var AfricasTalking, sms;
@@ -14,43 +13,48 @@ describe('SMS', function () {
         sms = AfricasTalking.SMS;
     });
 
-    it('validates options', function () {
-
+    describe('validation', function () {
         var options = { };
 
-        (function() {
-            let p = sms.send(options);
-        }).should.throw();
+        it('#send() cannot be empty', function () {
+            return sms.send(options)
+                .should.be.rejected();
+        });
 
-        options.to = "+254718769882";
-        options.from = null;
-        options.message = null;
-        (function() {
-            let p = sms.send(options);
-        }).should.throw();
+        it('#send() must have to/from/message params', function () {
+            options.to = "+254718769882";
+            options.from = null;
+            options.message = null;
 
+            return sms.send(options)
+                .should.be.rejected();
+        });
 
-        options.enqueue = "Joe";
-        (function() {
-            let p = sms.sendBulk(options);
-        }).should.throw();
+        it('#sendBulk()', function () {
+            options.enqueue = "Joe";
+            return sms.sendBulk(options)
+                .should.be.rejected();
+        });
 
+        it('#sendPremium()', function () {
+            return sms.sendPremium(options)
+                .should.be.rejected();
+        });
 
-        (function() {
-            let p = sms.sendPremium(options);
-        }).should.throw();
+        it('#fetchMessages()', function () {
+            return sms.fetchMessages(options)
+                .should.be.rejected();
+        });
 
-        let p = sms.fetchMessages(options);
-        validate.isPromise(p).should.be.exactly(true);
+        it('#createSubscription()', function () {
+            return sms.createSubscription(options)
+                .should.be.rejected();
+        });
 
-        (function() {
-            let p = sms.createSubscription(options);
-        }).should.throw();
-
-        (function() {
-            let p = sms.fetchSubscription(options);
-        }).should.throw();
-
+        it('#fetchSubscription()', function () {
+            return sms.fetchSubscription(options)
+                .should.be.rejected();
+        });
     });
 
 
@@ -74,6 +78,7 @@ describe('SMS', function () {
             to: "254718769882",
             message: "This is a test"
         };
+
         sms.send(opts)
             .then(function (resp) {
                 resp.should.have.property('SMSMessageData');

--- a/test/ussd.js
+++ b/test/ussd.js
@@ -103,8 +103,4 @@ describe('USSD', function () {
                 done();
             });
     });
-
-
-
-
 });


### PR DESCRIPTION
This commit return refactors the SMS library to return all errors (validation + HTTP) as a promise rejection.  This allows a library consumer to bundle all failure logic in the `.catch()` promise method instead of mixing `try { /* ... */ } catch (e) { /* ... */ }` statements.

@aksalj, I've only refactored the `SMS` library.  If you think this method of handling errors is decent, I can ago ahead an fill in the rest before the PR is merged.  Any feedback is appreciated!

/cc @ianjuma 