### PR TITLE
chore(lib): migrate to uniform promise rejection

### DIFF
--- a/lib/airtime.js
+++ b/lib/airtime.js
@@ -18,9 +18,11 @@ Airtime.prototype.send = function (params) {
     let _self       = this;
     let options     = _.cloneDeep(params);
     let _recipients = [];
+    let validationError;
 
     // Validate params
     let _validateParams = function () {
+
 
         var constraints = {
             recipients: function (value) {
@@ -70,24 +72,23 @@ Airtime.prototype.send = function (params) {
                         '%{currency} %{amount}',
                         { currency: currency, amount: amount }
                     );
-		    _recipients.push( { 'phoneNumber': phone, 'amount': recipient.amount });
+		            _recipients.push( { 'phoneNumber': phone, 'amount': recipient.amount });
                 };
 
                 return null;
-
             }
         };
 
-        let error = validate(options, constraints);
-        if (error) {
-            // TODO should this be rejected by promise instead?
-            throw error;
-        }
+        validationError = validate(options, constraints);
     }
 
     _validateParams();
 
     return new Promise(function (resolve, reject) {
+
+        if (validationError) {
+            return reject(validationError);
+        }
 
         let body = {
             username: _self.options.username,

--- a/lib/payment.js
+++ b/lib/payment.js
@@ -9,145 +9,148 @@ var Common   = require('./common');
 
 
 function Payment(options) {
-  this.options = options;
+    this.options = options;
 }
 
 
 Payment.prototype.checkOut = function (params) {
- 
-  let options = _.cloneDeep(params);
-  let _self   = this;
 
-  // Validate params
-  let _validateParams = function () {
- 
-      var constraints = {
-        phoneNumber: function (value) {
+    let options = _.cloneDeep(params);
+    let _self   = this;
+    let validationError;
 
-          if (validate.isEmpty(value)) {
-            return {
-              presence: {
-                message: 'is required'
-              }
-            };
-          }
-          if (!(/^\+?\d+$/).test(value)) {
-            return {
-                format: 'must not contain invalid phone number'
-            };
-          }
+    // Validate params
+    let _validateParams = function () {
 
-          return null;
-        },
+        var constraints = {
+          phoneNumber: function (value) {
 
-        productName: function (value) {
-
-          if (validate.isEmpty(value)) {
-            return {
+            if (validate.isEmpty(value)) {
+              return {
                 presence: {
-                    message: 'is required'
+                  message: 'is required'
                 }
-            };
+              };
+            }
+            if (!(/^\+?\d+$/).test(value)) {
+              return {
+                  format: 'must not contain invalid phone number'
+              };
+            }
+
+            return null;
+          },
+
+          productName: function (value) {
+
+            if (validate.isEmpty(value)) {
+              return {
+                  presence: {
+                      message: 'is required'
+                  }
+              };
+            }
+            if (!(/\S/).test(value)) {
+              return {
+                  format: 'must not contain invalid productName - eg. Space'
+              };
+            }
+
+            return null;
+          },
+
+          currencyCode: function (value) {
+
+            if (validate.isEmpty(value)) {
+              return {
+                  presence: {
+                      message: 'is required'
+                  }
+              };
+            }
+
+            return null;
+          },
+
+          metadata: function (value) {
+
+            if (validate.isEmpty(value)) {
+              return {
+                  presence: {
+                      message: 'is required'
+                  }
+              };
+            }
+
+            return null;
+          },
+
+          amount: function (value) {
+
+            if (validate.isEmpty(value)) {
+              return {
+                  presence: {
+                      message: 'is required'
+                  }
+              };
+            }
+            if (!validate.isNumber(value)) {
+              return {
+                  format: 'must not contain invalid amount. Must be a number.'
+              };
+            }
+
+            return null;
           }
-          if (!(/\S/).test(value)) {
-            return {
-                format: 'must not contain invalid productName - eg. Space'
-            };
+        };
+
+        let error = validate(options, constraints);
+        if (error) {
+          var msg = "";
+          for (var k in error) {
+              msg += error[k] + "; ";
           }
 
-          return null;
-        },
-
-        currencyCode: function (value) {
-
-          if (validate.isEmpty(value)) {
-            return {
-                presence: {
-                    message: 'is required'
-                }
-            };
-          }
-
-          return null;
-        },
-
-        metadata: function (value) {
-
-          if (validate.isEmpty(value)) {
-            return {
-                presence: {
-                    message: 'is required'
-                }
-            };
-          }
-
-          return null;
-        },
-
-        amount: function (value) {
-
-          if (validate.isEmpty(value)) {
-            return {
-                presence: {
-                    message: 'is required'
-                }
-            };
-          }
-          if (!validate.isNumber(value)) {
-            return {
-                format: 'must not contain invalid amount. Must be a number.'
-            };
-          }
-
-          return null;
+          validationError = new Error(msg);
         }
-      };
+    }
 
-      let error = validate(options, constraints);
-      if (error) {
-        // TODO should this be rejected by promise instead?
-	
-        var msg = "";
-        for (var k in error) {
-            msg += error[k] + "; ";
+    _validateParams();
+
+    return new Promise(function (resolve, reject) {
+
+        if (validationError) {
+            return reject(validationError);
         }
-        throw new Error(msg);
-      }
-  }
 
-  _validateParams();
+        let body = {
+            username     : _self.options.username,
+            productName  : options.productName,
+            phoneNumber  : options.phoneNumber,
+            currencyCode : options.currencyCode,
+            amount       : options.amount,
+            metadata     : options.metadata
+        };
 
-  return new Promise(function (resolve, reject) {
 
-    let body = {
-      username     : _self.options.username,
-      productName  : options.productName,
-      phoneNumber  : options.phoneNumber,
-      currencyCode : options.currencyCode,
-      amount       : options.amount,
-      metadata     : options.metadata
-    };
-    console.log(body);
+        let rq = unirest.post(Common.MOBILE_PAYMENT_URL + '/checkout/v1');
+        rq.headers({
+            apikey       : _self.options.apiKey,
+            Accept       : _self.options.format,
+            'Content-Type' : 'application/json'
+        });
 
-    let rq = unirest.post(Common.MOBILE_PAYMENT_URL + '/checkout/v1');
-    rq.headers({
-        apikey       : _self.options.apiKey,
-        Accept       : _self.options.format,
-	'Content-Type' : 'application/json'
+        rq.send(body);
+
+        rq.end(function (resp) {
+            if (resp.status === 201) {
+                // API returns CREATED on success
+                resolve(resp.body);
+            } else {
+                reject(resp.error || resp.body);
+            }
+        });
     });
-
-    rq.send(body);
-
-    rq.end(function (resp) {
-        if (resp.status === 201) {
-            // API returns CREATED on success
-            resolve(resp.body);
-        } else {
-            reject(resp.error || resp.body);
-        }
-    });
-  });
 };
-
 
 module.exports = Payment;

--- a/lib/ussd.js
+++ b/lib/ussd.js
@@ -44,8 +44,9 @@ function ExpressHandler(handler) {
                     }
                 });
 
+                // express uses next(err) to pass back errors
                 if (badOptions) {
-                    throw badOptions;
+                    return next(badOptions);
                 }
 
                 var response = opts.response;

--- a/test/airtime.js
+++ b/test/airtime.js
@@ -15,41 +15,47 @@ describe('AIRTIME', function(){
         airtime = AfricasTalking.AIRTIME;
     });
 
-    it('validates options', function(){
-
+    describe('validation', function () {
         var options = {};
 
-        (function() {
-            let p = airtime.send(options);
-        }).should.throw();
+        it('#send() cannot be empty', function () {
+            return airtime.send(options)
+                .should.be.rejected();
+        });
 
         options.recipients = [];
-        (function() {
-            let p = airtime.send(options);
-        }).should.throw();
+
+        it('#send() rejects have empty recipients', function () {
+            return airtime.send(options)
+                .should.be.rejected();
+        });
 
         options.recipients.push(
-            {phoneNumber: 'not phone', amount:'NaN'}
-            );
-        (function() {
-            let p = airtime.send(options);
-        }).should.throw();
+            { phoneNumber: 'not phone', amount: 'NaN' }
+        );
+
+        it('#send() rejects invalid options', function () {
+            return airtime.send(options)
+                .should.be.rejected();
+        });
 
         options.recipients = [
-            {phoneNumber: '0712345678', amount:9}
+            { phoneNumber: '0712345678', amount: 9 }
         ];
-        (function() {
-            let p = airtime.send(options);
-        }).should.throw();
+
+        it('#send() amount must be greater than 10', function () {
+            return airtime.send(options)
+                .should.be.rejected();
+        });
 
         options.recipients = [
             {phoneNumber: '0712345678', amount:10001}
         ];
-        (function() {
-            let p = airtime.send(options);
-        }).should.throw();
 
-
+        it('#send() amount must be less than 10000', function () {
+            return airtime.send(options)
+                .should.be.rejected();
+        });
     });
 
     it('sends airtime to one', function (done) {
@@ -98,7 +104,6 @@ describe('AIRTIME', function(){
                 console.error(err);
                 done();
             });
-
     });
 
 


### PR DESCRIPTION
This commit migrates the remaining library functions to reject errors via the returned promise instead of using `throw`.  This allows consumers to group all their error handling in the `.catch()` promise method instead of mixed `try {} catch (e) {}` blocks.  The unit tests have been updated to detect promise errors.

There are some minor spacing fixes in `payment.js` changing double space to four spaces as used by the other files in the library.

Closes #16.