### PR TITLE
downgrade unirest to a bugfree version

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "grpc": "^1.24.2",
     "lodash": "^4.17.15",
     "querystring": "^0.2.0",
-    "unirest": "^0.6.0",
+    "unirest": "^0.5.1",
     "validate.js": "^0.13.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The current unirest version used by the SDK throws an error resulting from a bug referenced here: [Make unirest compatible to mime 2.* versions #129](https://github.com/Kong/unirest-nodejs/pull/129) . 