### PR TITLE
Add requester to B2B

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ For more information on:
   - `recipients`: A list of consumers that will receive the money. `REQUIRED`
 
 
-- `mobileB2B({ productName, provider, transferType, currencyCode, destinationChannel, destinationAccount, amount, metadata })`:   Send mobile money to busness.
+- `mobileB2B({ productName, provider, transferType, currencyCode, destinationChannel, destinationAccount, amount, requester, metadata })`:   Send mobile money to busness.
 
   - `productName`: Your payment product. `REQUIRED`
   - `provider`: Provider used to process request. Checkout  `payments.PROVIDER.*`. `REQUIRED`
@@ -207,6 +207,7 @@ For more information on:
   - `destinationChannel`: Name or number of channel to receive payment. `REQUIRED`
   - `destinationAccount`: Account name used to receive money. `REQUIRED`
   - `amount`: Amount to transfer. `REQUIRED`
+  - `requester`: PhoneNumber through which KPLC will send tokens when using B2B to buy electricity tokens.
   - `metadata`: Additional info to go with the transfer
 
 - `mobileData(productName, recipients)`: Send mobile data to customers.

--- a/lib/payments.js
+++ b/lib/payments.js
@@ -522,6 +522,15 @@ Payments.prototype.mobileB2B = function (params) {
                 return null;
             },
 
+            requester: function (value) {
+                if (value && !(/^\+?\d+$/).test(value)) {
+                    return {
+                        format: 'must not contain invalid phone number'
+                    };
+                }
+                return null;
+            },
+
             metadata: function (value) {
                 if (value && !validate.isObject(value)) {
                     return {
@@ -570,6 +579,7 @@ Payments.prototype.mobileB2B = function (params) {
             amount,
             destinationAccount,
             destinationChannel,
+            requester,
             metadata
         } = options;
 
@@ -582,6 +592,7 @@ Payments.prototype.mobileB2B = function (params) {
             amount,
             destinationAccount,
             destinationChannel,
+            requester,
             metadata
         };
 


### PR DESCRIPTION
We recently updated the B2B API to enable clients pay for tokens.

The new B2B API has a new field in the request body called requester which allows insertion of a phone number through which KPLC will send tokens.

```
{
  "username": "username",
  "productName": "productname",
  "provider" : "Mpesa",
  "transferType": "BusinessPaybill",
    "currencyCode": "KES",
       "amount": 100,
       "destinationChannel" : "888880", 
       "destinationAccount": "01450717531", 
       "requester":"2547XX...",
      "metadata": {
        "shopId": "1234",
        "itemId": "abcdef"
      }
}
```
