### PR TITLE
move gRPC dependency to dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@hapi/joi": "^16.1.7",
     "axios": "^0.21.1",
     "body-parser": "^1.19.0",
-    "grpc": "^1.24.3",
     "lodash": "^4.17.15",
     "querystring": "^0.2.0",
     "unirest": "^0.6.0",
@@ -40,6 +39,7 @@
   },
   "devDependencies": {
     "express": "^4.17.1",
+    "grpc": "^1.24.3",
     "mocha": "^6.2.3",
     "nyc": "^14.1.1",
     "should": "^13.2.3",


### PR DESCRIPTION
As far as I can see, the gRPC dependency is only required for running tests and there's no need to include it in production builds.