### PR TITLE
Fixed condition that checks if phone numbers in an array are valid

### DIFF
--- a/lib/sms.js
+++ b/lib/sms.js
@@ -18,7 +18,7 @@ function SMS(options) {
 
         // Validate params
         const _validateParams = function () {
-
+            const phoneNumberRegex = !/^\+\d{1,3}\d{3,}$/
             const constraints = {
 
                 to: function (value, attributes, attributeName, options, constraints) {
@@ -35,7 +35,7 @@ function SMS(options) {
                     }
 
                     if (validate.isString(value)) {
-                        let isInvalid = !/^\+\d{1,3}\d{3,}$/.test(value);
+                        let isInvalid = phoneNumberRegex.test(value);
                         if (isInvalid) {
                             return {
                                 format: "must be a valid phone number"
@@ -44,11 +44,13 @@ function SMS(options) {
                     }
 
                     if (validate.isArray(value)) {
-                        let foundInvalid = false;
+                        let phoneNumbersValidArr = [];
+                        let invalidPhoneNumbers = []
                         value.forEach(function (phone) {
-                            foundInvalid = !/^\+\d{1,3}\d{3,}$/.test(phone);
+                            phoneNumbersValidArr.push(phoneNumberRegex.test(phone));
                         });
-                        if (foundInvalid) {
+                        invalidPhoneNumbers = phoneNumbersValidArr.filter(phoneNumber => phoneNumber === false)
+                        if (invalidPhoneNumbers.length > 0) {
                             return {
                                 format: "must NOT contain invalid phone number"
                             }
@@ -100,11 +102,7 @@ function SMS(options) {
 
         // Multiple recipients?
         if (validate.isArray(params.to)) {
-            if (params.to.length === 1) {
-                params.to = params.to[0];
-            } else {
-                params.to = params.to.join();
-            }
+            params.to = params.to.join();
         }
 
         return new Promise(function (resolve, reject) {


### PR DESCRIPTION
The condition that checks for invalid phone numbers in [https://github.com/AfricasTalkingLtd/africastalking-node.js/blob/master/lib/sms.js#L46](url) only checks validity last value in array. 
This PR fixes that.