### PR TITLE
Move from v0.5.8 to 0.5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "africastalking",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Official AfricasTalking node.js API wrapper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# What's changed?

- Removed the inclusion of the tests'  coverage folder and files from npm.