### PR TITLE
Hotfix: Re-sync NPM and GH readme by updating package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "africastalking",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "description": "Official AfricasTalking node.js API wrapper",
   "main": "index.js",
   "scripts": {

--- a/test/mobileData.js
+++ b/test/mobileData.js
@@ -6,7 +6,6 @@ let AfricasTalking, mobileData;
 
 describe('Mobile Data Bundles', function(){
 
-    this.timeout(15000);
 
     before(function () {
         AfricasTalking = require('../lib')(fixtures.TEST_ACCOUNT);

--- a/test/mobileData.js
+++ b/test/mobileData.js
@@ -6,6 +6,7 @@ let AfricasTalking, mobileData;
 
 describe('Mobile Data Bundles', function(){
 
+    this.timeout(15000);
 
     before(function () {
         AfricasTalking = require('../lib')(fixtures.TEST_ACCOUNT);


### PR DESCRIPTION
The goal of this PR is to have NPM at par with Github.
The problem is that Github is ahead of NPM.
As a result, the initialization section of the README.md file in NPM says ```AfricasTalking.MOBILEDATA``` instead of ```AfricasTalking.MOBILE_DATA```.

A version bump fixes this, as Github actions will automatically run `npm publish` once the master branch gets updated. 