### PR TITLE
Feat improve sms test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,9 @@
 
 Take a look at the [API docs here](https://developers.africastalking.com).
 
-
 ## Install
 
-You can install the package from [npm](https://npmjs.com/package/africastalking) by running: 
+You can install the package from [npm](https://npmjs.com/package/africastalking) by running:
 
 ```bash
 $ npm install --save africastalking
@@ -25,28 +24,29 @@ The package needs to be configured with your app username and API key, which you
 
 ```javascript
 const credentials = {
-    apiKey: 'YOUR_API_KEY',         // use your sandbox app API key for development in the test environment
-    username: 'YOUR_USERNAME',      // use 'sandbox' for development in the test environment
+  apiKey: "YOUR_API_KEY", // use your sandbox app API key for development in the test environment
+  username: "YOUR_USERNAME", // use 'sandbox' for development in the test environment
 };
-const AfricasTalking = require('africastalking')(credentials);
+const AfricasTalking = require("africastalking")(credentials);
 
 // Initialize a service e.g. SMS
-const sms = AfricasTalking.SMS
+const sms = AfricasTalking.SMS;
 
 // Use the service
 const options = {
-    to: ['+254711XXXYYY', '+254733YYYZZZ'],
-    message: "I'm a lumberjack and its ok, I work all night and sleep all day"
-}
+  to: ["+254711XXXYYY", "+254733YYYZZZ"],
+  message: "I'm a lumberjack and its ok, I work all night and sleep all day",
+};
 
 // Send message and capture the response or error
-sms.send(options)
-    .then( response => {
-        console.log(response);
-    })
-    .catch( error => {
-        console.log(error);
-    });
+sms
+  .send(options)
+  .then((response) => {
+    console.log(response);
+  })
+  .catch((error) => {
+    console.log(error);
+  });
 ```
 
 See [example](example/) for more usage examples.
@@ -71,124 +71,102 @@ Initialize the SDK as a requirement by doing `require('africastalking')(options)
 
 - [Application Service](#application) : `AfricasTalking.APPLICATION`
 
-
 ## Services
 
 All methods are asynchronous
 
 All phone numbers use the international format. e.g. `+234xxxxxxxx`.
 
-
 ### `SMS`
 
 - `send({ to, senderId, message, enqueue })`: Send an SMS to one or more phone numbers
 
 - `send([{ to, senderId, message, enqueue }])`: Send multiple SMSes to one or more phone numbers
- 
   - `to`: Recipient(s) phone number. Can either a single phone number or an array of phone numbers `REQUIRED`
   - `senderId`: Shortcode or alphanumeric ID that is registered with Africa's Talking account
   - `message`: SMS content. `REQUIRED`
   - `enqueue`: Set to true if you would like to deliver as many messages to the API without waiting for an acknowledgement from telcos.
 
 - `sendPremium({ to, from, message, enqueue, keyword, linkId, retryDurationInHours })`: Send premium SMS
-
   - `keyword`: You premium product keyword
   - `linkId`: We forward the `linkId` to your application when the user send a message to your service
   - `retryDurationInHours`: It specifies the number of hours your subscription message should be retried in case it's not delivered to the subscriber
 
 - `fetchMessages({ lastReceivedId })`: Manually retrieve your messages
-
   - `lastReceivedId`: "This is the id of the message that you last processed". Defaults to `0`
 
 - `fetchSubscription({ shortCode, keyword, lastReceivedId })`: Fetch your premium subscription data
-
   - `shortCode`: This is the premium short code mapped to your account. `REQUIRED`
   - `keyword`: A premium keyword under the above short code and mapped to your account. `REQUIRED`
   - `lastReceivedId`: "This is the id of the message that you last processed". Defaults to `0`
 
-
 - `createSubscription({ shortCode, keyword, phoneNumber })`: Create a premium subscription
-
   - `shortCode`: This is the premium short code mapped to your account. `REQUIRED`
   - `keyword`: A premium keyword under the above short code and mapped to your account. `REQUIRED`
-  - `phoneNumber`:  The phone number to be subscribed. `REQUIRED`
-
+  - `phoneNumber`: The phone number to be subscribed. `REQUIRED`
 
 For more information on:
+
 - SMS service: [https://developers.africastalking.com/docs/sms/overview](https://developers.africastalking.com/docs/sms/overview)
 - How to fetch subscriptions: [https://developers.africastalking.com/docs/sms/premium_subscriptions/fetch](https://developers.africastalking.com/docs/sms/premium_subscriptions/fetch)
 - How to listen for subscription notifications: [https://developers.africastalking.com/docs/sms/notifications](https://developers.africastalking.com/docs/sms/notifications)
 
-
 ### `Airtime`
 
-  - `send({ recipients })`: Send airtime to a bunch of phone numbers. 
+- `send({ recipients })`: Send airtime to a bunch of phone numbers.
+  - `recipients`: An array of objects containing the following keys:
+    - `phoneNumber`: Recipient of airtime. `REQUIRED`.
+    - `currencyCode`: 3-digit ISO format currency code. `REQUIRED`.
+    - `amount`: Amount to charge. `REQUIRED`.
 
-    - `recipients`: An array of objects containing the following keys:
-      - `phoneNumber`: Recipient of airtime. `REQUIRED`.
-      - `currencyCode`: 3-digit ISO format currency code. `REQUIRED`.
-      - `amount`: Amount to charge. `REQUIRED`.
+  - `maxNumRetry`: This allows you to specify the maximum number of retries in case of failed airtime deliveries due to various reasons such as telco unavailability. The default retry period is 8 hours and retries occur every 60seconds. For example, setting `maxNumRetry=4` means the transaction will be retried every 60seconds for the next 4 hours.`OPTIONAL`.
 
-    - `maxNumRetry`: This allows you to specify the maximum number of retries in case of failed airtime deliveries due to various reasons such as telco unavailability. The default retry period is 8 hours and retries occur every 60seconds. For example, setting `maxNumRetry=4` means the transaction will be retried every 60seconds for the next 4 hours.`OPTIONAL`.
+- `findTransactionStatus(transactionId)`: Find the status of a given airtime transaction.
+  - `transactionId`: ID of the transaction you would like to find.
 
-  - `findTransactionStatus(transactionId)`: Find the status of a given airtime transaction.
-
-    - `transactionId`: ID of the transaction you would like to find.
-
-
-  For more information, please read [https://developers.africastalking.com/docs/airtime/sending](https://developers.africastalking.com/docs/airtime/sending)
-
+For more information, please read [https://developers.africastalking.com/docs/airtime/sending](https://developers.africastalking.com/docs/airtime/sending)
 
 ### `MobileData`
 
 - `send({ productName, recipients })`
+  - `productName`: This is the application's product name.
+  - `recipients`: An array of objects containing the following keys:
+    - `phoneNumber`: Recipient of the mobile data. `REQUIRED`.
+    - `quantity`: a numeric value for the amount of mobile data. It is based on the available mobile data package[(see "Bundle Package" column of mobile data pricing)](https://africastalking.com/pricing). `REQUIRED`.
+    - `unit`: The units for the specified data quantity, the format is: `MB` or `GB`. It is based on the available mobile data package[(see "Bundle Package" column of mobile data pricing)](https://africastalking.com/pricing). `REQUIRED`.
+    - `validity`: The period of the data bundle’s validity this can be `Day`, `Week`, `BiWeek`, `Month`, or `Quarterly`. It is based on the available mobile data package [(see "Validity" column of mobile data pricing)](https://africastalking.com/pricing). `REQUIRED`.
+    - `metadata`: A JSON object of any metadata that you would like us to associate with the request. `REQUIRED`.
 
-    - `productName`: This is the application's product name.
-    - `recipients`: An array of objects containing the following keys:
-      - `phoneNumber`: Recipient of the mobile data. `REQUIRED`.
-      - `quantity`: a numeric value for the amount of mobile data. It is based on the available mobile data package[(see "Bundle Package" column of mobile data pricing)](https://africastalking.com/pricing). `REQUIRED`.
-      - `unit`: The units for the specified data quantity, the format is: ``MB`` or ``GB``. It is based on the available mobile data package[(see "Bundle Package" column of mobile data pricing)](https://africastalking.com/pricing). `REQUIRED`.
-      - `validity`: The period of the data bundle’s validity this can be `Day`, `Week`, `BiWeek`, `Month`, or `Quarterly`. It is based on the available mobile data package [(see "Validity" column of mobile data pricing)](https://africastalking.com/pricing). `REQUIRED`.
-      - `metadata`:  A JSON object of any metadata that you would like us to associate with the request. `REQUIRED`.
-
-
-- `findTransaction({ transactionId })`:  Find a mobile data transaction
+- `findTransaction({ transactionId })`: Find a mobile data transaction
 
 - `fetchWalletBalance()`: Fetch a mobile data product balance
 
 For more information, please read the [https://developers.africastalking.com/docs/data/overview](https://developers.africastalking.com/docs/data/overview)
 
-
 ### `Voice`
 
 - `call({ callFrom, callTo })`: Initiate a phone call
-
-    - `callFrom`: Your Africa's Talking issued virtual phone number. `REQUIRED`
-    - `callTo`: Comma-separated string of phone numbers to call. `REQUIRED`
-    - `clientRequestId`: Additional information that can be used to tag the call in your callback URL.
-
+  - `callFrom`: Your Africa's Talking issued virtual phone number. `REQUIRED`
+  - `callTo`: Comma-separated string of phone numbers to call. `REQUIRED`
+  - `clientRequestId`: Additional information that can be used to tag the call in your callback URL.
 
 - `fetchQuedCalls({ phoneNumber })`: Get queued calls
-
-    - `phoneNumber`: Your Africa's Talking issued virtual phone number. `REQUIRED`
-
+  - `phoneNumber`: Your Africa's Talking issued virtual phone number. `REQUIRED`
 
 - `uploadMediaFile({ phoneNumber, url })`: Upload voice media file
-
-    - `phoneNumber`: Your Africa's Talking issued virtual phone number. `REQUIRED`
-    - `url`: URL to your media file. `REQUIRED`
-
+  - `phoneNumber`: Your Africa's Talking issued virtual phone number. `REQUIRED`
+  - `url`: URL to your media file. `REQUIRED`
 
 > Helpers that will construct proper `xml` to send back to Africa's Taking API when it comes `POST`ing.
+
 - `Say`, `Play`, `GetDigits`, `Dial`, `Record`, `Enqueue`, `Dequeue`, `Conference`, `Redirect`, `Reject`
-> Remember to send back an HTTP 200.
+  > Remember to send back an HTTP 200.
 
 For more information, please read [https://developers.africastalking.com/docs/voice/overview](https://developers.africastalking.com/docs/voice/overview) and [issue #15](https://github.com/AfricasTalkingLtd/africastalking-node.js/issues/15)
 
 ### `USSD`
 
 For more information, please read [https://developers.africastalking.com/docs/ussd/overview](https://developers.africastalking.com/docs/ussd/overview)
-
 
 ### `Token`
 
@@ -198,13 +176,11 @@ For more information, please read [https://developers.africastalking.com/docs/us
 
 - `checkSimSwapState([phoneNumbers])`: Check the sim swap state of a given [set of ] phone number(s).
 
-
 ### `Application`
 
 - `fetchApplicationData()`: Get app information. e.g. balance
 
 For more information, please read [https://developers.africastalking.com/docs/application](https://developers.africastalking.com/docs/application)
-
 
 ## Development
 
@@ -224,9 +200,8 @@ $ # add credentials AT_APP_API_KEY, AT_APP_USERNAME and TEST_PHONENUMBER to .env
 $ npm run test-windows
 ```
 
-
 ## Issues & Contribution
 
 If you find a bug, please file an issue on [our issue tracker on GitHub](https://github.com/AfricasTalkingLtd/africastalking-node.js/issues).
 
-If you want to help improve this library, just send send us a PR!
+If you want to help improve this library, just send us a PR!

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -756,7 +755,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1140,7 +1138,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -2027,7 +2024,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2235,7 +2231,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -2327,7 +2322,6 @@
       "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -2378,7 +2372,6 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -2395,7 +2388,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",

--- a/test/index.js
+++ b/test/index.js
@@ -56,7 +56,9 @@ describe('Initialization', function () {
     lib = require('../lib')(options) // eslint-disable-line no-unused-vars
     common = require('../lib/common')
 
-    common.BASE_URL.should.equal('https://api.sandbox.africastalking.com/version1')
+    common.BASE_URL.should.equal(
+      'https://api.sandbox.africastalking.com/version1'
+    )
     common.VOICE_URL.should.equal('https://voice.sandbox.africastalking.com')
   })
 })

--- a/test/sms.js
+++ b/test/sms.js
@@ -16,7 +16,13 @@ describe('SMS', function () {
     const options = {}
 
     it('Rejects invalid phone numbers', function () {
-      const phoneNumbers = ['+254713', '+2547XXXXXXXX', '0712345678', '+25571234567890', '']
+      const phoneNumbers = [
+        '+254713',
+        '+2547XXXXXXXX',
+        '0712345678',
+        '+25571234567890',
+        ''
+      ]
 
       const options = {
         to: phoneNumbers,
@@ -216,5 +222,15 @@ describe('SMS', function () {
         done()
       })
       .catch(done)
+  })
+
+  it('rejects premium SMS without keyword', function () {
+    const opts = {
+      to: fixtures.phoneNumber,
+      from: 'service',
+      message: 'missing keyword'
+    }
+
+    return sms.sendPremium(opts).should.be.rejected()
   })
 })

--- a/test/sms.js
+++ b/test/sms.js
@@ -8,8 +8,11 @@ describe('SMS', function () {
   this.timeout(5000)
 
   before(function () {
+    console.log(fixtures.TEST_ACCOUNT)
     AfricasTalking = require('../lib')(fixtures.TEST_ACCOUNT)
     sms = AfricasTalking.SMS
+
+    console.log('sms object', sms)
   })
 
   describe('validation', function () {
@@ -232,5 +235,30 @@ describe('SMS', function () {
     }
 
     return sms.sendPremium(opts).should.be.rejected()
+  })
+
+  it('rejects deleteSubscription without phoneNumber', function () {
+    const opts = {
+      shortCode: '46585',
+      keyword: 'TEST'
+    }
+
+    return sms.deleteSubscription(opts).should.be.rejected()
+  })
+
+  it('uses senderId when from is not provided', function (done) {
+    const opts = {
+      to: fixtures.phoneNumber,
+      senderId: 'ATTEST',
+      message: 'senderId test'
+    }
+
+    sms
+      .send(opts)
+      .then(function (resp) {
+        resp.should.have.property('SMSMessageData')
+        done()
+      })
+      .catch(done)
   })
 })


### PR DESCRIPTION
This PR improves the test coverage of the SMS module by introducing additional test cases that target previously untested logic paths, validation scenarios, and edge cases.

While working on expanding coverage, I also noticed that the current test suite performs direct API calls to the Africa's Talking sandbox instead of mocking HTTP requests, thereby returning 401 on those test cases. This PR therefore also opens a discussion on whether the project should continue using live integration-style tests or move toward mocked unit tests for improved reliability and development experience.