### PR TITLE
Feat increase test coverage

### DIFF
--- a/test/airtime.js
+++ b/test/airtime.js
@@ -13,14 +13,12 @@ describe('Airtime', function () {
 
   describe('validation', function () {
     it('#send() cannot be empty', function () {
-      return airtime.send({})
-        .should.be.rejected()
+      return airtime.send({}).should.be.rejected()
     })
 
     it('#send() must have phoneNumber/currencyCode/amount', function () {
-      return airtime.send(
-        { recipients: [{ phoneNumber: fixtures.phoneNumber }] }
-      )
+      return airtime
+        .send({ recipients: [{ phoneNumber: fixtures.phoneNumber }] })
         .should.be.rejected()
     })
 
@@ -49,9 +47,12 @@ describe('Airtime', function () {
     })
 
     it('#send() rejects invalid options', function () {
-      return airtime.send(
-        { recipients: [{ phoneNumber: 'not phone', currencyCode: '', amount: 'NaN' }] }
-      )
+      return airtime
+        .send({
+          recipients: [
+            { phoneNumber: 'not phone', currencyCode: '', amount: 'NaN' }
+          ]
+        })
         .should.be.rejected()
     })
   })
@@ -67,7 +68,8 @@ describe('Airtime', function () {
       ]
     }
 
-    airtime.send(opts)
+    airtime
+      .send(opts)
       .then(function (resp) {
         resp.should.have.property('responses')
         done()
@@ -77,7 +79,8 @@ describe('Airtime', function () {
 
   it('should find airtime transaction status', function (done) {
     const transactionId = 'ATPid_9b4xxxxxxxccb27b13225'
-    airtime.findTransactionStatus(transactionId)
+    airtime
+      .findTransactionStatus(transactionId)
       .then(function (resp) {
         resp.should.have.property('status')
         done()
@@ -102,11 +105,33 @@ describe('Airtime', function () {
       maxNumRetry: 1
     }
 
-    airtime.send(opts)
+    airtime
+      .send(opts)
       .then(function (resp) {
         resp.should.have.property('responses')
         done()
       })
       .catch(done)
+  })
+
+  it('sends airtime with idempotencyKey', function () {
+    const opts = {
+      idempotencyKey: 'unique-key-12345',
+      recipients: [
+        {
+          phoneNumber: fixtures.phoneNumber,
+          currencyCode: 'KES',
+          amount: 10
+        }
+      ]
+    }
+
+    return airtime.send(opts).then(function (resp) {
+      resp.should.have.property('responses')
+    })
+  })
+
+  it('rejects findTransactionStatus when transactionId is not provided', function () {
+    return airtime.findTransactionStatus(null).should.be.rejected()
   })
 })

--- a/test/sms.js
+++ b/test/sms.js
@@ -16,7 +16,13 @@ describe('SMS', function () {
     const options = {}
 
     it('Rejects invalid phone numbers', function () {
-      const phoneNumbers = ['+254713', '+2547XXXXXXXX', '0712345678', '+25571234567890', '']
+      const phoneNumbers = [
+        '+254713',
+        '+2547XXXXXXXX',
+        '0712345678',
+        '+25571234567890',
+        ''
+      ]
 
       const options = {
         to: phoneNumbers,
@@ -216,5 +222,54 @@ describe('SMS', function () {
         done()
       })
       .catch(done)
+  })
+
+  it('rejects premium SMS without keyword', function () {
+    const opts = {
+      to: fixtures.phoneNumber,
+      from: 'service',
+      message: 'missing keyword'
+    }
+
+    return sms.sendPremium(opts).should.be.rejected()
+  })
+
+  it('uses senderId as sender when from is not provided', function () {
+    const opts = {
+      to: fixtures.phoneNumber,
+      senderId: 'ATTEST',
+      message: 'senderId test'
+    }
+
+    return sms.send(opts).then(function (resp) {
+      resp.should.have.property('SMSMessageData')
+      resp.SMSMessageData.should.have.property('Recipients').with.lengthOf(1)
+      resp.SMSMessageData.Recipients[0].should.have.property('statusCode', 101)
+    })
+  })
+
+  it('handles partial failure in array send — valid and invalid objects mixed', function () {
+    const opts = [
+      {
+        to: fixtures.phoneNumber,
+        enqueue: true,
+        message: 'Valid message'
+      },
+      {
+        to: 'NOT_A_PHONE_NUMBER',
+        enqueue: true,
+        message: 'Invalid recipient'
+      }
+    ]
+
+    return sms.send(opts).then(function (results) {
+      results.should.be.instanceof(Array)
+      results.should.have.lengthOf(2)
+      // First should succeed
+      results[0].should.have.property('SMSMessageData')
+      // Second should return the failure shape from Promise.allSettled handler
+      results[1].should.have.property('SMSMessageData')
+      results[1].SMSMessageData.should.have.property('status', 'failed')
+    })
   })
 })

--- a/test/sms.js
+++ b/test/sms.js
@@ -108,6 +108,22 @@ describe('SMS', function () {
       .catch(done)
   })
 
+  it('rejects creates subscription when shortCode is missing', function () {
+    const opts = {
+      keyword: 'TESTKWD',
+      phoneNumber: fixtures.phoneNumber
+    }
+    return sms.createSubscription(opts).should.be.rejected()
+  })
+
+  it('rejects create subscription when phoneNumber is missing', function () {
+    const opts = {
+      shortCode: '46585',
+      keyword: 'TESTKWD'
+    }
+    return sms.createSubscription(opts).should.be.rejected()
+  })
+
   it('deletes subscription', function (done) {
     const opts = {
       shortCode: '46585',


### PR DESCRIPTION
**Add missing test coverage for SMS and Airtime modules**

**Summary**
This PR adds test cases for code paths in the SMS and Airtime modules that were not covered by the existing test suite.

**Motivation**
Several implementation branches had no corresponding tests, meaning regressions in those paths would go undetected. These additions bring the test suite in line with the full behaviour documented in the implementation.

**Note for maintainers**
While working on this PR I noticed the existing test suite makes real HTTP calls to the AfricasTalking API rather than using mocked responses. This causes most tests to fail with 401 Unauthorized when no valid credentials are provided.

I'd like to open a conversation on whether it's worth introducing a mocking layer using libraries like nock or sinon to intercept axios calls and return fixture responses, making the suite runnable without credentials.

Happy to take this on as a follow-up PR if the maintainers are aligned on the approach.