### PR TITLE
test(token): add error case coverage for generateAuthToken

### DIFF
--- a/test/mocks.js
+++ b/test/mocks.js
@@ -56,6 +56,14 @@ const mockToken = (nock) => {
       token: 'AT_some_token',
       lifetimeInSeconds: 3600
     })
+
+  nock('https://api.sandbox.africastalking.com')
+    .post('/auth-token/generate')
+    .reply(200, { token: 'None', description: 'Invalid credentials' })
+
+  nock('https://api.sandbox.africastalking.com')
+    .post('/auth-token/generate')
+    .replyWithError('Network failure')
 }
 
 const mockAirtime = (nock) => {

--- a/test/token.js
+++ b/test/token.js
@@ -2,13 +2,13 @@
 
 require('should')
 const joi = require('joi')
-const nock = require('nock')
 const fixtures = require('./fixtures')
 
 let token
 
 describe('Token', function () {
   before(function () {
+    fixtures.mockServices()
     const AfricasTalking = require('../lib')(fixtures.TEST_ACCOUNT)
     token = AfricasTalking.TOKEN
   })
@@ -26,18 +26,10 @@ describe('Token', function () {
   })
 
   it('rejects when API returns token: None', function () {
-    nock('https://api.sandbox.africastalking.com')
-      .post('/auth-token/generate')
-      .reply(200, { token: 'None', description: 'Invalid credentials' })
-
     return token.generateAuthToken().should.be.rejected()
   })
 
   it('rejects on network error', function () {
-    nock('https://api.sandbox.africastalking.com')
-      .post('/auth-token/generate')
-      .replyWithError('Network failure')
-
     return token.generateAuthToken().should.be.rejected()
   })
 })

--- a/test/token.js
+++ b/test/token.js
@@ -1,13 +1,20 @@
 'use strict'
 
+require('should')
 const joi = require('joi')
+const nock = require('nock')
 const fixtures = require('./fixtures')
 
-describe('Token', function () {
-  it('generates auth token', function (done) {
-    const AfricasTalking = require('../lib')(fixtures.TEST_ACCOUNT)
+let token
 
-    const p = AfricasTalking.TOKEN.generateAuthToken()
+describe('Token', function () {
+  before(function () {
+    const AfricasTalking = require('../lib')(fixtures.TEST_ACCOUNT)
+    token = AfricasTalking.TOKEN
+  })
+
+  it('generates auth token', function (done) {
+    const p = token.generateAuthToken()
     joi.assert(p, joi.object().instance(Promise))
 
     p.then(function (resp) {
@@ -16,5 +23,21 @@ describe('Token', function () {
       done()
     })
       .catch(done)
+  })
+
+  it('rejects when API returns token: None', function () {
+    nock('https://api.sandbox.africastalking.com')
+      .post('/auth-token/generate')
+      .reply(200, { token: 'None', description: 'Invalid credentials' })
+
+    return token.generateAuthToken().should.be.rejected()
+  })
+
+  it('rejects on network error', function () {
+    nock('https://api.sandbox.africastalking.com')
+      .post('/auth-token/generate')
+      .replyWithError('Network failure')
+
+    return token.generateAuthToken().should.be.rejected()
   })
 })


### PR DESCRIPTION
Add missing test coverage for two untested rejection paths in `lib/token.js`:
- when the API returns `{ token: 'None' }` (invalid credentials)
- when a network error occurs

Additionally:

- `should `was never imported directly; the test silently depended on `sms.js` running first and monkey-patching `Object.prototype`
- The SDK instance was created inside the `it`callback instead of a shared `before` hook.

Note: 

The `generates auth token` success test relies on the nock interceptor registered by `airtime.js`'s `before` hook via `fixtures.mockServices()`. Running `test/token.js` in isolation will fail for that test without real sandbox credentials or `NO_NOCK=true`. 
